### PR TITLE
Add CreativeAI course (Siggraph Asia 2018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ We have also created a Slack workplace for people around the globe to ask questi
 
 [Paper Collection for 3D Understanding](https://www.cs.princeton.edu/courses/archive/spring15/cos598A/cos598A.html#Estimating)
 
+[CreativeAI: Deep Learning for Graphics](http://geometry.cs.ucl.ac.uk/creativeai/)
+
 <a name="datasets" />
 
 ## Datasets


### PR DESCRIPTION
Thanks for the great list of things related to 3d machine learning!
We have presented a course titled 'CreativeAI: Deep Learning for Graphics', at Siggraph Asia 2018 which could fit well into the list of courses (especially Part 7: 3D domains), so I created this pull request for your consideration.
